### PR TITLE
增加休眠时间选项和删除文末大图选项

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ go get github.com/pkg/errors
 $ ./geekpdf -h
 Usage of ./geekpdf:
   -c string
-    	Cellphone
+        Cellphone
   -i int
-    	Product ID
+        Product ID
   -p string
-    	Path to store pdf (default "pdf/")
+        Path to store pdf (default "pdf/")
+  -t int
+        Request Time Sleep (default 5)
   -w string
-    	Password
+        Password
 ```

--- a/README.md
+++ b/README.md
@@ -35,3 +35,6 @@ Usage of ./geekpdf:
   -w string
         Password
 ```
+
+### TODO
+[]: 太长的代码会被截断。

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ $ ./geekpdf -h
 Usage of ./geekpdf:
   -c string
         Cellphone
+  -d    Delete Bottom Pic
   -i int
         Product ID
   -p string

--- a/geek/geekpdf.go
+++ b/geek/geekpdf.go
@@ -134,6 +134,7 @@ func (g *GeekTime) makeRequest(url string, body interface{}) (request *http.Requ
 	request, err = http.NewRequest(http.MethodPost, url, bytes.NewBuffer(bodyBytes))
 	request.Header.Add("Content-Type", "application/json")
 	request.Header.Add("Origin", "https://time.geekbang.org")
+	request.Header.Add("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36")
 
 	for _, cookie := range g.cookies {
 		request.AddCookie(cookie)

--- a/geek/util.go
+++ b/geek/util.go
@@ -6,6 +6,13 @@ import (
 	"github.com/pkg/errors"
 )
 
+func DeletePic(use bool, article string) string {
+	if use && article[len(article)-114:len(article)-107] == "<p><img" {
+		return article[:len(article)-114]
+	}
+	return article
+}
+
 func SaveArticleAsPdf(article string, path string) (err error) {
 	if article == "" {
 		return errors.New("article is empty")

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ var (
 	path      string
 	cid       int
 	sleep     int
+	deletepic bool
 )
 
 func main() {
@@ -60,7 +61,7 @@ func main() {
 		}).Info("Loading article success")
 
 		pdfPath := path + article.ArticleTitle + ".pdf"
-		err = geek.SaveArticleAsPdf(article.ArticleContent, pdfPath)
+		err = geek.SaveArticleAsPdf(geek.DeletePic(deletepic, article.ArticleContent), pdfPath)
 		if err != nil {
 			log.WithError(err).WithFields(log.Fields{
 				"title":    article.ArticleTitle,
@@ -97,6 +98,7 @@ func initCmd() {
 	flag.StringVar(&path, "p", "pdf/", "Path to store pdf")
 	flag.IntVar(&cid, "i", 0, "Product ID")
 	flag.IntVar(&sleep, "t", 5, "Request Time Sleep")
+	flag.BoolVar(&deletepic, "d", false, "Delete Bottom Pic")
 	flag.Parse()
 
 	if cellphone == "" || password == "" {

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"geekpdf/geek"
 	log "github.com/sirupsen/logrus"
 	"os"
+	"time"
 )
 
 var (
@@ -12,6 +13,7 @@ var (
 	password  string
 	path      string
 	cid       int
+	sleep     int
 )
 
 func main() {
@@ -43,12 +45,12 @@ func main() {
 		"count":     len(articleList),
 	}).Info("Loading article list success")
 
-	for _, article := range articleList {
-		article, err := g.Article(article.ID)
+	for _, a := range articleList {
+		article, err := g.Article(a.ID)
 		if err != nil {
 			log.WithError(err).WithFields(log.Fields{
-				"articleId": article.ID,
-				"title":     article.ArticleTitle,
+				"articleId": a.ID,
+				"title":     a.ArticleTitle,
 			}).Error("Loading article failed")
 			continue
 		}
@@ -71,6 +73,7 @@ func main() {
 			"title":     article.ArticleTitle,
 			"filePath":  pdfPath,
 		}).Info("Save pdf success")
+		time.Sleep(time.Second * time.Duration(sleep))
 	}
 }
 
@@ -93,6 +96,7 @@ func initCmd() {
 	flag.StringVar(&password, "w", "", "Password")
 	flag.StringVar(&path, "p", "pdf/", "Path to store pdf")
 	flag.IntVar(&cid, "i", 0, "Product ID")
+	flag.IntVar(&sleep, "t", 5, "Request Time Sleep")
 	flag.Parse()
 
 	if cellphone == "" || password == "" {


### PR DESCRIPTION
1. 之前没出现过。今天发现极客时间会限制单位时间请求次数，出错在响应头中提示`X-GEEK-WARN: rate limit`，返回状态码是451。实测每次请求后休眠一小段时间可规避这个问题。
2. 最近几个月的专栏在每篇文章的文末放了一个大大的推广图。制作PDF不太需要这个。故增加了删除函数。鉴于最早的专栏可能没有这个图。删除推广图的选项默认关闭。